### PR TITLE
Add WebSocket heartbeat to prevent idle disconnects

### DIFF
--- a/src/hooks/useGameSocket.ts
+++ b/src/hooks/useGameSocket.ts
@@ -24,7 +24,14 @@ export function useGameSocket(sessionId: string) {
       console.error("WebSocket error:", err);
     };
 
+    const heartbeat = setInterval(() => {
+      if (ws.readyState === WebSocket.OPEN) {
+        ws.send(JSON.stringify({ type: "ping" }));
+      }
+    }, 30000);
+
     return () => {
+      clearInterval(heartbeat);
       ws.close();
       wsRef.current = null;
     };


### PR DESCRIPTION
Sends a ping message every 30 seconds to keep the connection alive through nginx's proxy_read_timeout.